### PR TITLE
月度更新: 2025年10月

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,56 @@
+# Changelog
+
+所有值得注意的变更都会记录在此文件中。
+
+格式基于 [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)，
+版本号采用 `YYYY.MM[.PATCH]` 格式。
+
+## [Unreleased]
+
+## [2025.10] - 2025-10-21
+
+### Added
+
+#### 人 (People)
+
+- **[DIYgod](https://diygod.me/)** (技术博主) - RSSHub 作者，充满温度的开源项目创作者
+- **[23.4ド(イチリ)](https://x.com/234itiri)** (漫画家) - 《堕天计画》系列作者
+
+#### 组织/社区 (Organizations/Communities)
+
+- **[AliceSoft](https://www.alicesoft.com/)** (游戏公司) - 成立于 1989 年的日本成人游戏公司，《兰斯》系列制作方
+- **[Qruppo](https://qruppo.com/)** (游戏公司) - 新锐游戏公司，《抜きゲーみたいな島》系列开发商
+- **[Intelligent Systems](https://www.intsys.co.jp/)** (游戏公司) - 任天堂第二方，《火焰纹章》系列制作方
+- **[香草社 (Vanillaware)](https://mzh.moegirl.org.cn/Vanillaware)** (游戏公司) - 以精美 2D 美术著称，《圣兽之王》《十三机兵防卫圈》制作方
+
+#### 物 (Things)
+
+- **[MacBook Air M1](https://support.apple.com/kb/SP825?locale=zh_CN)** - 16G RAM 512G SSD 主力工作电脑
+- **[Raspberry Pi 4 Model B](https://www.raspberrypi.com/products/raspberry-pi-4-model-b/)** (8G RAM) - 运行 Home Assistant OS
+- **[Logitech MX Keys](https://www.logitech.com/zh-cn/products/keyboards/mx-keys-mac-wireless-keyboard.920-009559.html)** - 办公用机械键盘
+- **[iPad Pro M1 11 寸](https://www.apple.com/cn/ipad-pro/)** (256G) - 用于看漫画和副屏
+- **[Nintendo Switch 续航版](https://www.nintendo.com/switch/)** - 日版，主力游戏机
+- **[Claude Code](https://claude.ai/code)** - AI 编程助手
+- **[onefetch](https://github.com/o2sh/onefetch)** - Git 仓库信息展示工具
+- **Setapp 相关应用** - CleanMyMac X, CleanShot X, Bartender 等多个实用工具
+
+### Changed
+
+- 更新 DIYgod 条目，标注 XLog 基本不可用状态
+- 更新各设备使用状态（MacBook Air 移到宿舍、MX Master 3 连接 Windows 主机等）
+
+### Removed
+
+- **Arc 浏览器** - 移除，改用其他浏览器方案
+
+### Technical
+
+- 添加 CHANGELOG.md 维护变更历史
+- 添加月度更新工作流程到 CLAUDE.md
+- 添加 GitHub Actions 自动发布到 XLog
+- 添加 GitHub Actions 链接检查
+- 规范化版本发布流程（PR + Tag + Release）
+
+---
+
+[Unreleased]: https://github.com/niracler/plrom/compare/main...HEAD

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,201 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Repository Overview
+
+This is a personal inventory repository (plrom - People, Communities, Things) that maintains a curated list of favorite content creators, companies, tools, and products. The content is written in Chinese and automatically published to XLog (a decentralized blogging platform on Crossbell) when changes are pushed to the main branch.
+
+## Publishing System
+
+### Core Publishing Script
+
+The [publish.sh](publish.sh) script is the heart of the publishing system. It:
+
+1. **Parses metadata** from the frontmatter in [README.md](README.md) (between `<!--` and `-->` markers)
+2. **Extracts fields**: `title`, `summary`, `cover`, `slug`, `tags`, `note_id`
+3. **Publishes to XLog** via the Crossbell API:
+   - If `note_id` exists: **Updates** the existing note (POST to `/notes/{note_id}/metadata`)
+   - If `note_id` is empty: **Creates** a new note (PUT to `/notes`)
+
+### Metadata Format
+
+The README.md must have frontmatter structured like:
+
+```markdown
+<!--
+title: 人 X 社区 X 物 - $(date +%Y-%m-%d)
+tags: [ "life", "software", "hardware", "community", "people", "tools", "xlog" ]
+cover: https://ipfs.crossbell.io/ipfs/QmR5AtZLDJqXUgn9gcYLKbcnRtGA6QtA14Xrzh6PuTsM9c
+slug: plrom
+summary: 关于我关注的人和物。这个主题很个人化...
+note_id: 273
+date: 2024-09-26
+modified: 2024-09-30
+-->
+```
+
+**Important**: All fields except `note_id` are required for publishing to succeed.
+
+### Character ID
+
+The Crossbell character ID (`57410`) is hardcoded in [publish.sh:3](publish.sh#L3). This identifies the blog owner on the Crossbell network.
+
+## Common Commands
+
+### Manual Publishing
+
+```bash
+# Requires XLOG_TOKEN environment variable
+export XLOG_TOKEN="your-token-here"
+./publish.sh
+```
+
+### Link Checking
+
+The repository uses linkspector to validate URLs in README.md:
+
+```bash
+# Check all links (runs automatically via GitHub Actions)
+npx linkspector .
+```
+
+Configuration is in [.linkspector.yml](.linkspector.yml) which ignores certain domains that frequently timeout or block bots.
+
+## GitHub Actions Workflow
+
+### Auto-Publish Workflow
+
+[.github/workflows/auto-publish.yml](.github/workflows/auto-publish.yml):
+
+- **Trigger**: Pushes to `main` branch
+- **Process**: Installs `jq`, runs [publish.sh](publish.sh)
+- **Secret Required**: `XLOG_TOKEN` must be set in repository secrets
+
+### Link Checker Workflow
+
+[.github/workflows/check-links.yml](.github/workflows/check-links.yml):
+
+- Validates all links in README.md on pushes and PRs
+
+## Content Structure
+
+The [README.md](README.md) is organized into three main sections:
+
+1. **人 (People)**: Content creators categorized by type
+   - 技术博主 (Tech bloggers)
+   - 作家 (Writers)
+   - 漫画家 (Manga artists)
+   - 导演 (Directors)
+   - UP 主 & 油管主 (Video creators)
+   - 播客 (Podcasters)
+   - 歌手 & 音乐制作人 (Musicians)
+
+2. **组织或社区 (Organizations/Communities)**
+   - 组织 (Organizations)
+   - 游戏 & 动画公司 (Game & animation companies)
+   - 技术新闻 (Tech news)
+
+3. **物 (Things)**: Hardware, software, and tools
+   - 电脑及配件 (Computers & accessories)
+   - 软件工具 (Software tools)
+   - Various personal devices
+
+## Editing Guidelines
+
+When making changes to README.md:
+
+1. **Preserve metadata structure**: Always keep the frontmatter format intact
+2. **Update modified date**: Change the `modified:` field to current date when making content changes
+3. **Maintain consistency**: Follow the existing format with emojis, links, and commentary style
+4. **Use details tags**: Deprecated or sensitive content goes in `<details>` sections
+5. **Test links**: Run link checking before committing to avoid broken URLs
+
+## Development Workflow
+
+### Update Cycle
+
+This repository follows a **monthly update cycle**:
+
+- **Frequency**: Once per month
+- **Versioning**: `YYYY.MM` format (e.g., 2025.10, 2025.11)
+- **Process**: Each monthly update gets a PR, version tag, and changelog entry
+
+### Branch Naming
+
+```
+feature/update-YYYY-MM    # Monthly updates
+feature/add-game-companies # Feature additions
+fix/broken-links          # Bug fixes
+docs/update-guide         # Documentation updates
+```
+
+### Monthly Update Process
+
+1. **Create branch**: `git checkout -b feature/update-2025-10`
+
+2. **Update content** in [README.md](README.md):
+   - Add new people/communities/things
+   - Remove items no longer followed
+   - Update `modified` date in frontmatter
+
+3. **Update [CHANGELOG.md](CHANGELOG.md)**:
+   ```markdown
+   ## [2025.10] - 2025-10-21
+
+   ### Added
+   - **[Name](link)** (category) - Reason for adding
+
+   ### Removed
+   - **Name** (category) - Reason for removal
+   ```
+
+4. **Check links**: `npx linkspector .`
+
+5. **Create PR**:
+   ```bash
+   git add README.md CHANGELOG.md
+   git commit -m "feat: 2025年10月月度更新"
+   git push origin feature/update-2025-10
+   gh pr create --title "月度更新: 2025年10月"
+   ```
+
+6. **After merge, create release**:
+   ```bash
+   git checkout main && git pull
+   git tag -a v2025.10 -m "2025.10"
+   git push origin v2025.10
+   ```
+
+### Commit Message Format
+
+```
+feat: add new items or monthly update
+fix: fix broken links or errors
+docs: documentation updates
+chore: releases, maintenance
+```
+
+### Versioning
+
+- **Monthly releases**: `YYYY.MM` (e.g., v2025.10)
+- **Hotfixes**: `YYYY.MM.PATCH` (e.g., v2025.10.1)
+
+### Changelog Maintenance
+
+[CHANGELOG.md](CHANGELOG.md) follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format with sections:
+
+- **Added**: New people/communities/things with reasons
+- **Removed**: Removed items with reasons
+- **Changed**: Description or category updates
+- **Fixed**: Link fixes, error corrections
+
+Each entry should explain **why** the change was made, not just what changed.
+
+## Technical Notes
+
+- The repository contains **no traditional code** - it's purely content and publishing automation
+- Shell script uses **POSIX-compatible syntax** (dash) for maximum portability
+- JSON processing relies on `jq` being available
+- The publishing script uses curl to interact with Crossbell API
+- Authentication is via Bearer token in the Authorization header

--- a/README.md
+++ b/README.md
@@ -190,7 +190,11 @@ modified: 2024-09-30
 
 - [板机社(TRIGGER)](https://zh.moegirl.org.cn/TRIGGER(%E5%85%AC%E5%8F%B8)#) - 独一档的画风以及质量，基本是属于它出的都可以看并且很好看的地步。（话说我差点以为《天元突破》也是他们的。原来是他们老东家的作品）
 - [京都动画](https://zh.moegirl.org.cn/%E4%BA%AC%E9%83%BD%E5%8A%A8%E7%94%BB) - 也是属于基本上每一部都可以看一下的公司。
-- [香草社](https://mzh.moegirl.org.cn/Vanillaware) - 玩过他的《圣兽之王》，美术是真的顶。
+- [AliceSoft](https://www.alicesoft.com/) - 成立于 1989 年的日本成人游戏制作公司，以《兰斯》系列闻名，每次人生发生重大变动时都会重玩《战国兰斯》。
+- [Qruppo](https://qruppo.com/) - 新锐游戏公司，以《抜きゲーみたいな島》(拔作岛)系列受到关注，Henpri 让我狠狠爱上，后续一定要玩拔作岛系列。
+- ~~[Eushully](https://zh.moegirl.org.cn/Eushully) - 成立于 2005 年的 E 社，曾是我游戏启蒙的公司，上大学前内存只有 2G 时它的 RPG 游戏就是我的主要娱乐。~~
+- [Intelligent Systems](https://www.intsys.co.jp/) - 成立于 1986 年的任天堂第二方开发商，《火焰纹章》系列制作方，在 Switch上 游戏时长最长的游戏系列。
+- [香草社](https://mzh.moegirl.org.cn/Vanillaware) - 成立于 2002 年的 Vanillaware，以精美2D美术著称，玩过《圣兽之王》美术真的顶，《十三机兵防卫圈》一直在我的 todo list 里。
 
 ### 📰 技术新闻
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<!-- 
+<!--
 title: 人 X 社区 X 物 - $(date +%Y-%m-%d)
 tags: [ "life", "software", "hardware", "community", "people", "tools", "xlog" ]
 cover: https://ipfs.crossbell.io/ipfs/QmR5AtZLDJqXUgn9gcYLKbcnRtGA6QtA14Xrzh6PuTsM9c
@@ -6,12 +6,12 @@ slug: plrom
 summary: 关于我关注的人和物。这个主题很个人化，我喜欢的内容，别人或许会觉得不适合。毕竟这与我的阅历和经验密切相关。不过，我希望能列出一些我认为不错的东西，给你一些启发。
 note_id: 273
 date: 2024-09-26
-modified: 2024-09-30
+modified: 2025-10-21
 -->
 
 # plrom
 
-这个主题很个人化，我喜欢的内容，别人或许会觉得不适合。毕竟这与我的阅历和经验密切相关。不过，我希望能列出一些我认为不错的东西，给你一些启发。
+关于我关注的人和物。这个主题很个人化，我喜欢的内容，别人或许会觉得不适合。毕竟这与我的阅历和经验密切相关。不过，我希望能列出一些我认为不错的东西，给你一些启发。
 
 > 我一般用 RSS 订阅以下列表中的人或组织，并且几乎每篇都读。  
 > 顺序不分先后，纯靠心情
@@ -215,8 +215,7 @@ modified: 2024-09-30
   - [西部数据(WD) 2TB 移动硬盘 USB 3.0](https://www.wd.com/products/portable-storage/my-passport.html) - 中间有段时间用于备份我的 MacBook Air 的数据，但是经常会因为太慢甚至将我电脑卡死，所以就更换用途了。现在是用来作为 AutoBangumi 的动画存储。
 - [Logitech MX Keys](https://www.logitech.com/zh-cn/products/keyboards/mx-keys-mac-wireless-keyboard.920-009559.html) - 拿去公司上班用了
 
-(远远称不上整洁的桌面😂)
-![28D407F9-1DD6-48B1-8F06-B58A44EF392A_1_105_c.jpeg](https://image.niracler.com/2025/09/ae548461d451ed36ab16001c1832028c.jpeg)
+![远远称不上整洁的桌面😂](https://image.niracler.com/2025/09/ae548461d451ed36ab16001c1832028c.jpeg)
 
 ### 🏷️ 随身设备
 
@@ -531,8 +530,7 @@ modified: 2024-09-30
 - [Home Assistant Companion](https://companion.home-assistant.io) - 最近日常手机上都是开 tailscale 来让 HA 识别我是否到家了，到家之前自动开空调电脑之类的。
 - [Apple Home](https://www.apple.com/cn/apple-home/) - 设备价格偏高,目前只有少量设备。不过配合 Home Assistant 后应该会有更多可能性。
 
-(最近摸鱼时调的一个 HA 面板)
-![CleanShot 2025-05-23 at 15.08.17@2x.png](https://image.niracler.com/2025/05/8770f3aca85cdd8a358bf0e17426c353.png)
+![最近摸鱼时调的一个 HA 面板](https://image.niracler.com/2025/05/8770f3aca85cdd8a358bf0e17426c353.png)
 
 ### 🛒 购物
 
@@ -540,8 +538,8 @@ modified: 2024-09-30
 - [京东](https://www.jd.com/)(小程序) - 会员价值感逐渐降低。
 - [拼多多](https://www.pinduoduo.com/)(小程序) - 主要用于购买 Switch 游戏卡带、乐高、模型等娱乐用品。
 - [淘宝](https://www.taobao.com/) - 适合购买特殊商品,如台版书籍、外区充值卡等。
-- [闲鱼](https://www.goofish.com) - 因不愿花时间讨价还价,很少用于卖物。每年购买几件二手商品,在消费降级趋势下可能会增加使用频率。
-- [朴朴超市](http://www.pupumall.com) - 买菜以及生活用品之类的。
+- [闲鱼](https://www.goofish.com)(小程序) - 因不愿花时间讨价还价,很少用于卖物。每年购买几件二手商品,在消费降级趋势下可能会增加使用频率。
+- [朴朴超市](http://www.pupumall.com)(小程序) - 买菜以及生活用品之类的。
 
 <details>
 <summary>过期列表</summary>


### PR DESCRIPTION
## 📅 更新周期

2025年10月 (2025-10)

## 🎯 本次更新内容

本次是项目的首个正式版本发布，主要完成以下工作：

### ✨ 新增内容

#### 开发规范
- 添加 [CHANGELOG.md](CHANGELOG.md) 维护变更历史
- 在 [CLAUDE.md](CLAUDE.md) 中添加完整的月度更新工作流程

#### 内容总结
基于过去几个月的提交记录，总结了以下新增内容：

**人 (People)**
- DIYgod (RSSHub 作者)
- 23.4ド(イチリ) (《堕天计画》系列作者)

**组织/社区**
- AliceSoft (《兰斯》系列制作方)
- Qruppo (《抜きゲーみたいな島》开发商)
- Intelligent Systems (《火焰纹章》系列制作方)
- 香草社 Vanillaware (《圣兽之王》制作方)

**物 (Things)**
- MacBook Air M1, Raspberry Pi 4, iPad Pro M1
- Logitech MX Keys, Nintendo Switch
- Claude Code, onefetch
- Setapp 应用套装

### 📝 其他变更
- 更新 README.md frontmatter 的 modified 日期为 2025-10-21
- 记录设备使用状态变更
- 移除 Arc 浏览器

## ✅ 检查清单

- [x] 更新了 README.md frontmatter 中的 modified 日期
- [x] 创建了 CHANGELOG.md 并记录变更
- [x] 添加了开发工作流程到 CLAUDE.md
- [x] 保持了现有格式和风格
- [ ] 等待 GitHub Actions 链接检查通过

## 📋 后续步骤

合并后需要：
1. 创建版本 tag: `v2025.10`
2. 创建 GitHub Release
3. 自动发布到 XLog